### PR TITLE
Add additional tests for valid SQS attr values

### DIFF
--- a/lib/output/writer/sqs_test.go
+++ b/lib/output/writer/sqs_test.go
@@ -97,6 +97,14 @@ func TestSQSHeaderCheck(t *testing.T) {
 			k: "foo with space", v: "bar",
 			expected: false,
 		},
+		{
+			k: "iso date", v: "1997-07-16T19:20:30.45+01:00",
+			expected: true,
+		},
+		{
+			k: "has a char in the valid range", v: "#x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF - Ѱ",
+			expected: true,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Following the SQS docs, attr values can have any valid SQS body char. Those are shown here:

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html

```
#x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF 
```

Since `Ѱ = #x470 = 0x470` is in the range `#x20 to #xD7FF` the new tests should pass.